### PR TITLE
SharedLibraryLoader: Handle app bundles

### DIFF
--- a/app/src/main/java/com/wireguard/android/util/Extensions.kt
+++ b/app/src/main/java/com/wireguard/android/util/Extensions.kt
@@ -34,6 +34,10 @@ fun <T> List<T>.asString(): String {
     return TextUtils.join(", ", this)
 }
 
+fun <T> Array<out T>?.isNotNullOrEmpty(): Boolean {
+    return this != null && !isEmpty()
+}
+
 inline fun <reified T : Any> Any?.requireNonNull(message: String): T {
     if (this == null)
         throw NullPointerException(message)

--- a/app/src/main/java/com/wireguard/android/util/SharedLibraryLoader.kt
+++ b/app/src/main/java/com/wireguard/android/util/SharedLibraryLoader.kt
@@ -27,7 +27,7 @@ object SharedLibraryLoader {
 
         val zipFile: ZipFile
         try {
-            zipFile = ZipFile(File(context.applicationInfo.sourceDir), ZipFile.OPEN_READ)
+            zipFile = ZipFile(File(getApkPath(context)), ZipFile.OPEN_READ)
         } catch (e: IOException) {
             throw RuntimeException(e)
         }
@@ -57,5 +57,20 @@ object SharedLibraryLoader {
         if (noAbiException is RuntimeException)
             throw noAbiException
         throw RuntimeException(noAbiException)
+    }
+
+    private fun getApkPath(context: Context): String {
+        val splitDirs = context.applicationInfo.splitSourceDirs
+        if (splitDirs.isNotNullOrEmpty()) {
+            for (abi in Build.SUPPORTED_ABIS) {
+                for (splitDir in splitDirs) {
+                    val splits = splitDir.split("/")
+                    val apkName = splits[splits.size - 1]
+                    if (apkName.contains(abi.replace("-", "_")))
+                        return splitDir
+                }
+            }
+        }
+        return context.applicationInfo.sourceDir
     }
 }


### PR DESCRIPTION
When APKs are installed as app bundles, the base.apk
returned by ApplicationInfo#getSourceDir does not contain
any native libraries, so SharedLibraryLoader never finds
the library to load and everything just falls apart.

ApplicationInfo#getSplitSourceDirs returns an array of
split APKs including the one that contains native libraries
which we _can_ load libs manually from so spin up some
looping magic to automagically select the correct APK
for the loadSharedLibrary method to work off of.