### PR TITLE
Add and run spotless style check plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ branches:
 script:
   - |
       ./gradlew spotlessCheck && \
-      ./gradlew assemble bundle check
+      ./gradlew assemble check
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,9 @@ branches:
     - master
 
 script:
-  - ./gradlew spotlessCheck
-  - ./gradlew assemble bundle check
+  - |
+      ./gradlew spotlessCheck && \
+      ./gradlew assemble bundle check
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ branches:
     - master
 
 script:
-  - source ci/style-check.sh
+  - ./gradlew spotlessCheck
   - ./gradlew assemble bundle check
 
 notifications:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,10 @@ import java.io.FileInputStream
 import java.io.IOException
 import java.util.Properties
 
+apply {
+    from("../spotless.gradle")
+}
+
 plugins {
     id("com.android.application")
     id("kotlin-android")

--- a/app/src/main/java/com/wireguard/android/Application.kt
+++ b/app/src/main/java/com/wireguard/android/Application.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android
 
 import android.app.NotificationChannel

--- a/app/src/main/java/com/wireguard/android/Application.kt
+++ b/app/src/main/java/com/wireguard/android/Application.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android
 
 import android.app.NotificationChannel

--- a/app/src/main/java/com/wireguard/android/BootShutdownReceiver.kt
+++ b/app/src/main/java/com/wireguard/android/BootShutdownReceiver.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android
 
 import android.content.BroadcastReceiver

--- a/app/src/main/java/com/wireguard/android/BootShutdownReceiver.kt
+++ b/app/src/main/java/com/wireguard/android/BootShutdownReceiver.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android
 
 import android.content.BroadcastReceiver

--- a/app/src/main/java/com/wireguard/android/QuickTileService.kt
+++ b/app/src/main/java/com/wireguard/android/QuickTileService.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android
 
 import android.annotation.TargetApi

--- a/app/src/main/java/com/wireguard/android/QuickTileService.kt
+++ b/app/src/main/java/com/wireguard/android/QuickTileService.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android
 
 import android.annotation.TargetApi

--- a/app/src/main/java/com/wireguard/android/activity/BaseActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/BaseActivity.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.activity
 
 import android.os.Bundle

--- a/app/src/main/java/com/wireguard/android/activity/BaseActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/BaseActivity.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.activity
 
 import android.os.Bundle

--- a/app/src/main/java/com/wireguard/android/activity/MainActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/MainActivity.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.activity
 
 import android.content.Intent

--- a/app/src/main/java/com/wireguard/android/activity/MainActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/MainActivity.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.activity
 
 import android.content.Intent

--- a/app/src/main/java/com/wireguard/android/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/SettingsActivity.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.activity
 
 import android.content.pm.PackageManager

--- a/app/src/main/java/com/wireguard/android/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/SettingsActivity.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.activity
 
 import android.content.pm.PackageManager

--- a/app/src/main/java/com/wireguard/android/activity/ThemeChangeAwareActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/ThemeChangeAwareActivity.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.activity
 
 import android.content.SharedPreferences

--- a/app/src/main/java/com/wireguard/android/activity/ThemeChangeAwareActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/ThemeChangeAwareActivity.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.activity
 
 import android.content.SharedPreferences

--- a/app/src/main/java/com/wireguard/android/activity/TunnelCreatorActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/TunnelCreatorActivity.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.activity
 
 import android.os.Bundle

--- a/app/src/main/java/com/wireguard/android/activity/TunnelCreatorActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/TunnelCreatorActivity.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.activity
 
 import android.os.Bundle

--- a/app/src/main/java/com/wireguard/android/backend/Backend.kt
+++ b/app/src/main/java/com/wireguard/android/backend/Backend.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.backend
 
 import com.wireguard.android.model.Tunnel

--- a/app/src/main/java/com/wireguard/android/backend/Backend.kt
+++ b/app/src/main/java/com/wireguard/android/backend/Backend.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.backend
 
 import com.wireguard.android.model.Tunnel

--- a/app/src/main/java/com/wireguard/android/backend/GoBackend.kt
+++ b/app/src/main/java/com/wireguard/android/backend/GoBackend.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+*/
 package com.wireguard.android.backend
 
 import android.app.PendingIntent

--- a/app/src/main/java/com/wireguard/android/backend/GoBackend.kt
+++ b/app/src/main/java/com/wireguard/android/backend/GoBackend.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.backend
 
 import android.app.PendingIntent

--- a/app/src/main/java/com/wireguard/android/backend/WgQuickBackend.kt
+++ b/app/src/main/java/com/wireguard/android/backend/WgQuickBackend.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.backend
 
 import android.app.Notification

--- a/app/src/main/java/com/wireguard/android/backend/WgQuickBackend.kt
+++ b/app/src/main/java/com/wireguard/android/backend/WgQuickBackend.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.backend
 
 import android.app.Notification

--- a/app/src/main/java/com/wireguard/android/configStore/ConfigStore.kt
+++ b/app/src/main/java/com/wireguard/android/configStore/ConfigStore.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.configStore
 
 import com.wireguard.config.Config

--- a/app/src/main/java/com/wireguard/android/configStore/ConfigStore.kt
+++ b/app/src/main/java/com/wireguard/android/configStore/ConfigStore.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.configStore
 
 import com.wireguard.config.Config

--- a/app/src/main/java/com/wireguard/android/configStore/FileConfigStore.kt
+++ b/app/src/main/java/com/wireguard/android/configStore/FileConfigStore.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.configStore
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/configStore/FileConfigStore.kt
+++ b/app/src/main/java/com/wireguard/android/configStore/FileConfigStore.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.configStore
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/databinding/BindingAdapters.kt
+++ b/app/src/main/java/com/wireguard/android/databinding/BindingAdapters.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 @file:Suppress("Unused")
 
 package com.wireguard.android.databinding

--- a/app/src/main/java/com/wireguard/android/databinding/BindingAdapters.kt
+++ b/app/src/main/java/com/wireguard/android/databinding/BindingAdapters.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 @file:Suppress("Unused")
 
 package com.wireguard.android.databinding

--- a/app/src/main/java/com/wireguard/android/databinding/ItemChangeListener.kt
+++ b/app/src/main/java/com/wireguard/android/databinding/ItemChangeListener.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.databinding
 
 import android.view.LayoutInflater

--- a/app/src/main/java/com/wireguard/android/databinding/ItemChangeListener.kt
+++ b/app/src/main/java/com/wireguard/android/databinding/ItemChangeListener.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.databinding
 
 import android.view.LayoutInflater

--- a/app/src/main/java/com/wireguard/android/databinding/ObservableKeyedRecyclerViewAdapter.kt
+++ b/app/src/main/java/com/wireguard/android/databinding/ObservableKeyedRecyclerViewAdapter.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.databinding
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/databinding/ObservableKeyedRecyclerViewAdapter.kt
+++ b/app/src/main/java/com/wireguard/android/databinding/ObservableKeyedRecyclerViewAdapter.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.databinding
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/fragment/AppListDialogFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/AppListDialogFragment.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.fragment
 
 import android.app.Dialog

--- a/app/src/main/java/com/wireguard/android/fragment/AppListDialogFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/AppListDialogFragment.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.fragment
 
 import android.app.Dialog

--- a/app/src/main/java/com/wireguard/android/fragment/BaseFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/BaseFragment.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.fragment
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/fragment/BaseFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/BaseFragment.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.fragment
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/fragment/ConfigNamingDialogFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/ConfigNamingDialogFragment.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.fragment
 
 import android.app.Dialog

--- a/app/src/main/java/com/wireguard/android/fragment/ConfigNamingDialogFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/ConfigNamingDialogFragment.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.fragment
 
 import android.app.Dialog

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelDetailFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelDetailFragment.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.fragment
 
 import android.os.Bundle

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelDetailFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelDetailFragment.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.fragment
 
 import android.os.Bundle

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelEditorFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelEditorFragment.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.fragment
 
 import android.os.Bundle

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelEditorFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelEditorFragment.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.fragment
 
 import android.os.Bundle

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+*/
 package com.wireguard.android.fragment
 
 import android.app.Activity

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.fragment
 
 import android.app.Activity

--- a/app/src/main/java/com/wireguard/android/model/ApplicationData.kt
+++ b/app/src/main/java/com/wireguard/android/model/ApplicationData.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.model
 
 import android.graphics.drawable.Drawable

--- a/app/src/main/java/com/wireguard/android/model/ApplicationData.kt
+++ b/app/src/main/java/com/wireguard/android/model/ApplicationData.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.model
 
 import android.graphics.drawable.Drawable

--- a/app/src/main/java/com/wireguard/android/model/Tunnel.kt
+++ b/app/src/main/java/com/wireguard/android/model/Tunnel.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-// For statistics
+*/
 @file:Suppress("Unused")
 
 package com.wireguard.android.model

--- a/app/src/main/java/com/wireguard/android/model/Tunnel.kt
+++ b/app/src/main/java/com/wireguard/android/model/Tunnel.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 @file:Suppress("Unused")
 
 package com.wireguard.android.model

--- a/app/src/main/java/com/wireguard/android/model/TunnelManager.kt
+++ b/app/src/main/java/com/wireguard/android/model/TunnelManager.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.model
 
 import android.content.BroadcastReceiver

--- a/app/src/main/java/com/wireguard/android/model/TunnelManager.kt
+++ b/app/src/main/java/com/wireguard/android/model/TunnelManager.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.model
 
 import android.content.BroadcastReceiver

--- a/app/src/main/java/com/wireguard/android/preference/LogExporterPreference.kt
+++ b/app/src/main/java/com/wireguard/android/preference/LogExporterPreference.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.preference
 
 import android.Manifest

--- a/app/src/main/java/com/wireguard/android/preference/LogExporterPreference.kt
+++ b/app/src/main/java/com/wireguard/android/preference/LogExporterPreference.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.preference
 
 import android.Manifest

--- a/app/src/main/java/com/wireguard/android/preference/ToolsInstallerPreference.kt
+++ b/app/src/main/java/com/wireguard/android/preference/ToolsInstallerPreference.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.preference
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/preference/ToolsInstallerPreference.kt
+++ b/app/src/main/java/com/wireguard/android/preference/ToolsInstallerPreference.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.preference
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/preference/VersionPreference.kt
+++ b/app/src/main/java/com/wireguard/android/preference/VersionPreference.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.preference
 
 import android.content.ActivityNotFoundException

--- a/app/src/main/java/com/wireguard/android/preference/VersionPreference.kt
+++ b/app/src/main/java/com/wireguard/android/preference/VersionPreference.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.preference
 
 import android.content.ActivityNotFoundException

--- a/app/src/main/java/com/wireguard/android/preference/ZipExporterPreference.kt
+++ b/app/src/main/java/com/wireguard/android/preference/ZipExporterPreference.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.preference
 
 import android.Manifest

--- a/app/src/main/java/com/wireguard/android/preference/ZipExporterPreference.kt
+++ b/app/src/main/java/com/wireguard/android/preference/ZipExporterPreference.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.preference
 
 import android.Manifest

--- a/app/src/main/java/com/wireguard/android/util/ApplicationPreferences.kt
+++ b/app/src/main/java/com/wireguard/android/util/ApplicationPreferences.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2018 Harsh Shandilya. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.util
 
 import androidx.core.content.edit

--- a/app/src/main/java/com/wireguard/android/util/ApplicationPreferences.kt
+++ b/app/src/main/java/com/wireguard/android/util/ApplicationPreferences.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.util
 
 import androidx.core.content.edit

--- a/app/src/main/java/com/wireguard/android/util/AsyncWorker.kt
+++ b/app/src/main/java/com/wireguard/android/util/AsyncWorker.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.util
 
 import android.os.Handler

--- a/app/src/main/java/com/wireguard/android/util/AsyncWorker.kt
+++ b/app/src/main/java/com/wireguard/android/util/AsyncWorker.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.util
 
 import android.os.Handler

--- a/app/src/main/java/com/wireguard/android/util/ErrorMessages.kt
+++ b/app/src/main/java/com/wireguard/android/util/ErrorMessages.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.util
 
 import android.content.res.Resources

--- a/app/src/main/java/com/wireguard/android/util/ErrorMessages.kt
+++ b/app/src/main/java/com/wireguard/android/util/ErrorMessages.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.util
 
 import android.content.res.Resources

--- a/app/src/main/java/com/wireguard/android/util/ExceptionLoggers.kt
+++ b/app/src/main/java/com/wireguard/android/util/ExceptionLoggers.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.util
 
 import android.util.Log

--- a/app/src/main/java/com/wireguard/android/util/ExceptionLoggers.kt
+++ b/app/src/main/java/com/wireguard/android/util/ExceptionLoggers.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.util
 
 import android.util.Log

--- a/app/src/main/java/com/wireguard/android/util/Extensions.kt
+++ b/app/src/main/java/com/wireguard/android/util/Extensions.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.util
 
 import android.app.AlarmManager

--- a/app/src/main/java/com/wireguard/android/util/Extensions.kt
+++ b/app/src/main/java/com/wireguard/android/util/Extensions.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2018 Harsh Shandilya. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.util
 
 import android.app.AlarmManager

--- a/app/src/main/java/com/wireguard/android/util/KotlinCompanions.java
+++ b/app/src/main/java/com/wireguard/android/util/KotlinCompanions.java
@@ -7,34 +7,32 @@ package com.wireguard.android.util;
 
 import com.wireguard.android.model.Tunnel;
 import com.wireguard.android.model.TunnelManager;
+import java.util.ArrayList;
+import java.util.Set;
 import java9.util.concurrent.CompletableFuture;
 import java9.util.concurrent.CompletionStage;
 import java9.util.stream.StreamSupport;
 
-import java.util.ArrayList;
-import java.util.Set;
-
 /**
- * Slightly crufty workaround for Kotlin not supporting the CompletableFuture[]::new
- * expression, don't like it but what can we do :')
- * <p>
- * TODO: Get rid of this as soon as the ability is made available
+ * Slightly crufty workaround for Kotlin not supporting the CompletableFuture[]::new expression,
+ * don't like it but what can we do :')
+ *
+ * <p>TODO: Get rid of this as soon as the ability is made available
  */
 public final class KotlinCompanions {
 
-    public static CompletionStage<Void> streamForStateChange(final ObservableSortedKeyedArrayList<String, Tunnel> tunnels,
-                                                             final Set<String> previouslyRunning,
-                                                             final TunnelManager tunnelManager) {
-        return CompletableFuture.allOf(StreamSupport.stream(tunnels)
-                .filter(tunnel -> previouslyRunning.contains(tunnel.getName()))
-                .map(tunnel -> tunnelManager.setTunnelState(tunnel, Tunnel.State.UP))
-                .toArray(CompletableFuture[]::new));
+    public static CompletionStage<Void> streamForStateChange(
+            final ObservableSortedKeyedArrayList<String, Tunnel> tunnels,
+            final Set<String> previouslyRunning,
+            final TunnelManager tunnelManager) {
+        return CompletableFuture.allOf(
+                StreamSupport.stream(tunnels)
+                        .filter(tunnel -> previouslyRunning.contains(tunnel.getName()))
+                        .map(tunnel -> tunnelManager.setTunnelState(tunnel, Tunnel.State.UP))
+                        .toArray(CompletableFuture[]::new));
     }
 
     public static CompletableFuture[] streamForDeletion(final ArrayList<Tunnel> tunnels) {
-        return StreamSupport.stream(tunnels)
-                .map(Tunnel::delete)
-                .toArray(CompletableFuture[]::new);
+        return StreamSupport.stream(tunnels).map(Tunnel::delete).toArray(CompletableFuture[]::new);
     }
-
 }

--- a/app/src/main/java/com/wireguard/android/util/ObservableKeyedArrayList.java
+++ b/app/src/main/java/com/wireguard/android/util/ObservableKeyedArrayList.java
@@ -9,7 +9,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.databinding.ObservableArrayList;
 import com.wireguard.util.Keyed;
-
 import java.util.Collection;
 import java.util.ListIterator;
 import java.util.Objects;
@@ -20,20 +19,17 @@ import java.util.Objects;
  * restrictions on the order or duplication of keys, lookup by key, as well as all list modification
  * operations, require O(n) time.
  */
-
 public class ObservableKeyedArrayList<K, E extends Keyed<? extends K>>
         extends ObservableArrayList<E> implements ObservableKeyedList<K, E> {
     @Override
     public boolean add(@Nullable final E e) {
-        if (e == null)
-            throw new NullPointerException("Trying to add a null element");
+        if (e == null) throw new NullPointerException("Trying to add a null element");
         return super.add(e);
     }
 
     @Override
     public void add(final int index, @Nullable final E e) {
-        if (e == null)
-            throw new NullPointerException("Trying to add a null element");
+        if (e == null) throw new NullPointerException("Trying to add a null element");
         super.add(index, e);
     }
 
@@ -75,8 +71,7 @@ public class ObservableKeyedArrayList<K, E extends Keyed<? extends K>>
         final ListIterator<E> iterator = listIterator();
         while (iterator.hasNext()) {
             final int index = iterator.nextIndex();
-            if (Objects.equals(iterator.next().getKey(), key))
-                return index;
+            if (Objects.equals(iterator.next().getKey(), key)) return index;
         }
         return -1;
     }
@@ -86,24 +81,20 @@ public class ObservableKeyedArrayList<K, E extends Keyed<? extends K>>
         final ListIterator<E> iterator = listIterator(size());
         while (iterator.hasPrevious()) {
             final int index = iterator.previousIndex();
-            if (Objects.equals(iterator.previous().getKey(), key))
-                return index;
+            if (Objects.equals(iterator.previous().getKey(), key)) return index;
         }
         return -1;
     }
 
     @Override
     public E set(final int index, @Nullable final E e) {
-        if (e == null)
-            throw new NullPointerException("Trying to set a null key");
+        if (e == null) throw new NullPointerException("Trying to set a null key");
         return super.set(index, e);
     }
 
     @Override
     public boolean containsAllKeys(@NonNull Collection<? extends K> keys) {
-        for (final K key : keys)
-            if (!containsKey(key))
-                return false;
+        for (final K key : keys) if (!containsKey(key)) return false;
         return true;
     }
 }

--- a/app/src/main/java/com/wireguard/android/util/ObservableKeyedList.kt
+++ b/app/src/main/java/com/wireguard/android/util/ObservableKeyedList.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.util
 
 import androidx.databinding.ObservableList

--- a/app/src/main/java/com/wireguard/android/util/ObservableKeyedList.kt
+++ b/app/src/main/java/com/wireguard/android/util/ObservableKeyedList.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.util
 
 import androidx.databinding.ObservableList

--- a/app/src/main/java/com/wireguard/android/util/ObservableSortedKeyedArrayList.java
+++ b/app/src/main/java/com/wireguard/android/util/ObservableSortedKeyedArrayList.java
@@ -8,7 +8,6 @@ package com.wireguard.android.util;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.wireguard.util.Keyed;
-
 import java.util.*;
 
 /**
@@ -17,11 +16,9 @@ import java.util.*;
  * array-based nature of this class, insertion and removal of elements with anything but the largest
  * key still require O(n) time.
  */
-
 public class ObservableSortedKeyedArrayList<K, E extends Keyed<? extends K>>
         extends ObservableKeyedArrayList<K, E> implements ObservableSortedKeyedList<K, E> {
-    @Nullable
-    private final Comparator<? super K> comparator;
+    @Nullable private final Comparator<? super K> comparator;
     private final transient KeyList<K, E> keyList = new KeyList<>(this);
 
     public ObservableSortedKeyedArrayList(@Nullable final Comparator<? super K> comparator) {
@@ -33,8 +30,7 @@ public class ObservableSortedKeyedArrayList<K, E extends Keyed<? extends K>>
         final int insertionPoint = getInsertionPoint(element);
         if (insertionPoint < 0) {
             // Skipping insertion is non-destructive if the new and existing objects are the same.
-            if (element == get(-insertionPoint - 1))
-                return false;
+            if (element == get(-insertionPoint - 1)) return false;
             throw new IllegalArgumentException("Element with same key already exists in list");
         }
         super.add(insertionPoint, element);
@@ -54,16 +50,13 @@ public class ObservableSortedKeyedArrayList<K, E extends Keyed<? extends K>>
     @Override
     public boolean addAll(@NonNull final Collection<? extends E> elements) {
         boolean didChange = false;
-        for (final E e : elements)
-            if (add(e))
-                didChange = true;
+        for (final E e : elements) if (add(e)) didChange = true;
         return didChange;
     }
 
     @Override
     public boolean addAll(int index, @NonNull final Collection<? extends E> elements) {
-        for (final E e : elements)
-            add(index++, e);
+        for (final E e : elements) add(index++, e);
         return true;
     }
 
@@ -86,8 +79,8 @@ public class ObservableSortedKeyedArrayList<K, E extends Keyed<? extends K>>
         if (comparator != null) {
             return -Collections.binarySearch(keyList, e.getKey(), comparator) - 1;
         } else {
-            @SuppressWarnings("unchecked") final List<Comparable<? super K>> list =
-                    (List<Comparable<? super K>>) keyList;
+            @SuppressWarnings("unchecked")
+            final List<Comparable<? super K>> list = (List<Comparable<? super K>>) keyList;
             return -Collections.binarySearch(list, e.getKey()) - 1;
         }
     }
@@ -98,8 +91,8 @@ public class ObservableSortedKeyedArrayList<K, E extends Keyed<? extends K>>
         if (comparator != null) {
             index = Collections.binarySearch(keyList, key, comparator);
         } else {
-            @SuppressWarnings("unchecked") final List<Comparable<? super K>> list =
-                    (List<Comparable<? super K>>) keyList;
+            @SuppressWarnings("unchecked")
+            final List<Comparable<? super K>> list = (List<Comparable<? super K>>) keyList;
             index = Collections.binarySearch(list, key);
         }
         return index >= 0 ? index : -1;
@@ -131,8 +124,8 @@ public class ObservableSortedKeyedArrayList<K, E extends Keyed<? extends K>>
         if (comparator != null) {
             order = comparator.compare(e.getKey(), get(index).getKey());
         } else {
-            @SuppressWarnings("unchecked") final Comparable<? super K> key =
-                    (Comparable<? super K>) e.getKey();
+            @SuppressWarnings("unchecked")
+            final Comparable<? super K> key = (Comparable<? super K>) e.getKey();
             order = key.compareTo(get(index).getKey());
         }
         if (order != 0) {
@@ -149,8 +142,8 @@ public class ObservableSortedKeyedArrayList<K, E extends Keyed<? extends K>>
         return this;
     }
 
-    private static final class KeyList<K, E extends Keyed<? extends K>>
-            extends AbstractList<K> implements Set<K> {
+    private static final class KeyList<K, E extends Keyed<? extends K>> extends AbstractList<K>
+            implements Set<K> {
         private final ObservableSortedKeyedArrayList<K, E> list;
 
         private KeyList(final ObservableSortedKeyedArrayList<K, E> list) {

--- a/app/src/main/java/com/wireguard/android/util/ObservableSortedKeyedList.kt
+++ b/app/src/main/java/com/wireguard/android/util/ObservableSortedKeyedList.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.util
 
 import com.wireguard.util.Keyed

--- a/app/src/main/java/com/wireguard/android/util/ObservableSortedKeyedList.kt
+++ b/app/src/main/java/com/wireguard/android/util/ObservableSortedKeyedList.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.util
 
 import com.wireguard.util.Keyed

--- a/app/src/main/java/com/wireguard/android/util/RootShell.kt
+++ b/app/src/main/java/com/wireguard/android/util/RootShell.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2019 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.util
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/util/RootShell.kt
+++ b/app/src/main/java/com/wireguard/android/util/RootShell.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.util
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/util/SharedLibraryLoader.kt
+++ b/app/src/main/java/com/wireguard/android/util/SharedLibraryLoader.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.util
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/util/SharedLibraryLoader.kt
+++ b/app/src/main/java/com/wireguard/android/util/SharedLibraryLoader.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.util
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/util/ToolsInstaller.kt
+++ b/app/src/main/java/com/wireguard/android/util/ToolsInstaller.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.util
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/util/ToolsInstaller.kt
+++ b/app/src/main/java/com/wireguard/android/util/ToolsInstaller.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.util
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/viewmodel/ConfigProxy.kt
+++ b/app/src/main/java/com/wireguard/android/viewmodel/ConfigProxy.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.viewmodel
 
 import android.os.Parcel

--- a/app/src/main/java/com/wireguard/android/viewmodel/ConfigProxy.kt
+++ b/app/src/main/java/com/wireguard/android/viewmodel/ConfigProxy.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.viewmodel
 
 import android.os.Parcel

--- a/app/src/main/java/com/wireguard/android/viewmodel/InterfaceProxy.kt
+++ b/app/src/main/java/com/wireguard/android/viewmodel/InterfaceProxy.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.viewmodel
 
 import android.os.Parcel

--- a/app/src/main/java/com/wireguard/android/viewmodel/InterfaceProxy.kt
+++ b/app/src/main/java/com/wireguard/android/viewmodel/InterfaceProxy.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.viewmodel
 
 import android.os.Parcel

--- a/app/src/main/java/com/wireguard/android/viewmodel/PeerProxy.kt
+++ b/app/src/main/java/com/wireguard/android/viewmodel/PeerProxy.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.viewmodel
 
 import android.os.Parcel

--- a/app/src/main/java/com/wireguard/android/viewmodel/PeerProxy.kt
+++ b/app/src/main/java/com/wireguard/android/viewmodel/PeerProxy.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.viewmodel
 
 import android.os.Parcel

--- a/app/src/main/java/com/wireguard/android/widget/KeyInputFilter.java
+++ b/app/src/main/java/com/wireguard/android/widget/KeyInputFilter.java
@@ -11,10 +11,7 @@ import android.text.Spanned;
 import androidx.annotation.Nullable;
 import com.wireguard.crypto.Key;
 
-/**
- * InputFilter for entering WireGuard private/public keys encoded with base64.
- */
-
+/** InputFilter for entering WireGuard private/public keys encoded with base64. */
 public class KeyInputFilter implements InputFilter {
     private static boolean isAllowed(final char c) {
         return Character.isLetterOrDigit(c) || c == '+' || c == '/';
@@ -26,10 +23,13 @@ public class KeyInputFilter implements InputFilter {
 
     @Override
     @Nullable
-    public CharSequence filter(final CharSequence source,
-                               final int sStart, final int sEnd,
-                               final Spanned dest,
-                               final int dStart, final int dEnd) {
+    public CharSequence filter(
+            final CharSequence source,
+            final int sStart,
+            final int sEnd,
+            final Spanned dest,
+            final int dStart,
+            final int dEnd) {
         SpannableStringBuilder replacement = null;
         int rIndex = 0;
         final int dLength = dest.length();
@@ -38,9 +38,9 @@ public class KeyInputFilter implements InputFilter {
             final int dIndex = dStart + (sIndex - sStart);
             // Restrict characters to the base64 character set.
             // Ensure adding this character does not push the length over the limit.
-            if (((dIndex + 1 < Key.Format.BASE64.getLength() && isAllowed(c)) ||
-                    (dIndex + 1 == Key.Format.BASE64.getLength() && c == '=')) &&
-                    dLength + (sIndex - sStart) < Key.Format.BASE64.getLength()) {
+            if (((dIndex + 1 < Key.Format.BASE64.getLength() && isAllowed(c))
+                            || (dIndex + 1 == Key.Format.BASE64.getLength() && c == '='))
+                    && dLength + (sIndex - sStart) < Key.Format.BASE64.getLength()) {
                 ++rIndex;
             } else {
                 if (replacement == null)

--- a/app/src/main/java/com/wireguard/android/widget/MultiselectableRelativeLayout.kt
+++ b/app/src/main/java/com/wireguard/android/widget/MultiselectableRelativeLayout.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.widget
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/widget/MultiselectableRelativeLayout.kt
+++ b/app/src/main/java/com/wireguard/android/widget/MultiselectableRelativeLayout.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.widget
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/widget/NameInputFilter.kt
+++ b/app/src/main/java/com/wireguard/android/widget/NameInputFilter.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.widget
 
 import android.text.InputFilter

--- a/app/src/main/java/com/wireguard/android/widget/NameInputFilter.kt
+++ b/app/src/main/java/com/wireguard/android/widget/NameInputFilter.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.widget
 
 import android.text.InputFilter

--- a/app/src/main/java/com/wireguard/android/widget/SlashDrawable.java
+++ b/app/src/main/java/com/wireguard/android/widget/SlashDrawable.java
@@ -24,7 +24,8 @@ import androidx.annotation.Nullable;
 @TargetApi(Build.VERSION_CODES.N)
 public class SlashDrawable extends Drawable {
 
-    private static final float CORNER_RADIUS = Build.VERSION.SDK_INT < Build.VERSION_CODES.O ? 0f : 1f;
+    private static final float CORNER_RADIUS =
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.O ? 0f : 1f;
     private static final long QS_ANIM_LENGTH = 350;
     // These values are derived in un-rotated (vertical) orientation
     private static final float SLASH_WIDTH = 1.8384776f;
@@ -38,17 +39,18 @@ public class SlashDrawable extends Drawable {
     private static final float RIGHT = (CENTER_X + (SLASH_WIDTH / 2)) / SCALE;
     // Draw the slash washington-monument style; rotate to no-u-turn style
     private static final float DEFAULT_ROTATION = -45f;
-    private static final FloatProperty mSlashLengthProp = new FloatProperty<SlashDrawable>("slashLength") {
-        @Override
-        public void setValue(final SlashDrawable object, final float value) {
-            object.mCurrentSlashLength = value;
-        }
+    private static final FloatProperty mSlashLengthProp =
+            new FloatProperty<SlashDrawable>("slashLength") {
+                @Override
+                public void setValue(final SlashDrawable object, final float value) {
+                    object.mCurrentSlashLength = value;
+                }
 
-        @Override
-        public Float get(final SlashDrawable object) {
-            return object.mCurrentSlashLength;
-        }
-    };
+                @Override
+                public Float get(final SlashDrawable object) {
+                    return object.mCurrentSlashLength;
+                }
+            };
     private final Path mPath = new Path();
     private final Paint mPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final Drawable mDrawable;
@@ -80,8 +82,7 @@ public class SlashDrawable extends Drawable {
     }
 
     public void setRotation(final float rotation) {
-        if (mRotation == rotation)
-            return;
+        if (mRotation == rotation) return;
         mRotation = rotation;
         invalidateSelf();
     }
@@ -123,8 +124,7 @@ public class SlashDrawable extends Drawable {
                 scale(LEFT, width),
                 scale(TOP, height),
                 scale(RIGHT, width),
-                scale(TOP + mCurrentSlashLength, height)
-        );
+                scale(TOP + mCurrentSlashLength, height));
 
         mPath.reset();
         // Draw the slash vertically
@@ -147,8 +147,7 @@ public class SlashDrawable extends Drawable {
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
             canvas.clipPath(mPath, Region.Op.DIFFERENCE);
-        else
-            canvas.clipOutPath(mPath);
+        else canvas.clipOutPath(mPath);
 
         mDrawable.draw(canvas);
         canvas.restore();
@@ -158,7 +157,8 @@ public class SlashDrawable extends Drawable {
         return frac * width;
     }
 
-    private void updateRect(final float left, final float top, final float right, final float bottom) {
+    private void updateRect(
+            final float left, final float top, final float right, final float bottom) {
         mSlashRect.left = left;
         mSlashRect.top = top;
         mSlashRect.right = right;

--- a/app/src/main/java/com/wireguard/android/widget/ToggleSwitch.kt
+++ b/app/src/main/java/com/wireguard/android/widget/ToggleSwitch.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.widget
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/widget/ToggleSwitch.kt
+++ b/app/src/main/java/com/wireguard/android/widget/ToggleSwitch.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2013 The Android Open Source Project
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.widget
 
 import android.content.Context

--- a/app/src/main/java/com/wireguard/android/widget/fab/FloatingActionButtonBehavior.kt
+++ b/app/src/main/java/com/wireguard/android/widget/fab/FloatingActionButtonBehavior.kt
@@ -1,7 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
+*/
 @file:Suppress("Unused")
 
 package com.wireguard.android.widget.fab

--- a/app/src/main/java/com/wireguard/android/widget/fab/FloatingActionButtonBehavior.kt
+++ b/app/src/main/java/com/wireguard/android/widget/fab/FloatingActionButtonBehavior.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 @file:Suppress("Unused")
 
 package com.wireguard.android.widget.fab

--- a/app/src/main/java/com/wireguard/android/widget/fab/FloatingActionButtonRecyclerViewScrollListener.kt
+++ b/app/src/main/java/com/wireguard/android/widget/fab/FloatingActionButtonRecyclerViewScrollListener.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2018 Harsh Shandilya <msfjarvis@gmail.com>. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.android.widget.fab
 
 import androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/java/com/wireguard/android/widget/fab/FloatingActionButtonRecyclerViewScrollListener.kt
+++ b/app/src/main/java/com/wireguard/android/widget/fab/FloatingActionButtonRecyclerViewScrollListener.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.android.widget.fab
 
 import androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/java/com/wireguard/config/Attribute.kt
+++ b/app/src/main/java/com/wireguard/config/Attribute.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.config
 
 import android.text.TextUtils

--- a/app/src/main/java/com/wireguard/config/Attribute.kt
+++ b/app/src/main/java/com/wireguard/config/Attribute.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.config
 
 import android.text.TextUtils

--- a/app/src/main/java/com/wireguard/config/BadConfigException.kt
+++ b/app/src/main/java/com/wireguard/config/BadConfigException.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.config
 
 import com.wireguard.crypto.KeyFormatException

--- a/app/src/main/java/com/wireguard/config/BadConfigException.kt
+++ b/app/src/main/java/com/wireguard/config/BadConfigException.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.config
 
 import com.wireguard.crypto.KeyFormatException

--- a/app/src/main/java/com/wireguard/config/Config.kt
+++ b/app/src/main/java/com/wireguard/config/Config.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.config
 
 import com.wireguard.android.util.requireNonNull

--- a/app/src/main/java/com/wireguard/config/Config.kt
+++ b/app/src/main/java/com/wireguard/config/Config.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.config
 
 import com.wireguard.android.util.requireNonNull

--- a/app/src/main/java/com/wireguard/config/InetAddresses.kt
+++ b/app/src/main/java/com/wireguard/config/InetAddresses.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.config
 
 import java.lang.reflect.InvocationTargetException

--- a/app/src/main/java/com/wireguard/config/InetAddresses.kt
+++ b/app/src/main/java/com/wireguard/config/InetAddresses.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.config
 
 import java.lang.reflect.InvocationTargetException

--- a/app/src/main/java/com/wireguard/config/InetEndpoint.kt
+++ b/app/src/main/java/com/wireguard/config/InetEndpoint.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.config
 
 import org.threeten.bp.Duration

--- a/app/src/main/java/com/wireguard/config/InetEndpoint.kt
+++ b/app/src/main/java/com/wireguard/config/InetEndpoint.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.config
 
 import org.threeten.bp.Duration

--- a/app/src/main/java/com/wireguard/config/InetNetwork.kt
+++ b/app/src/main/java/com/wireguard/config/InetNetwork.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.config
 
 import java.net.Inet4Address

--- a/app/src/main/java/com/wireguard/config/InetNetwork.kt
+++ b/app/src/main/java/com/wireguard/config/InetNetwork.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.config
 
 import java.net.Inet4Address

--- a/app/src/main/java/com/wireguard/config/Interface.kt
+++ b/app/src/main/java/com/wireguard/config/Interface.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.config
 
 import com.wireguard.android.util.ApplicationPreferences

--- a/app/src/main/java/com/wireguard/config/Interface.kt
+++ b/app/src/main/java/com/wireguard/config/Interface.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.config
 
 import com.wireguard.android.util.ApplicationPreferences

--- a/app/src/main/java/com/wireguard/config/ParseException.kt
+++ b/app/src/main/java/com/wireguard/config/ParseException.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.config
 
 /**

--- a/app/src/main/java/com/wireguard/config/ParseException.kt
+++ b/app/src/main/java/com/wireguard/config/ParseException.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.config
 
 /**

--- a/app/src/main/java/com/wireguard/config/Peer.kt
+++ b/app/src/main/java/com/wireguard/config/Peer.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.config
 
 import com.wireguard.android.util.requireNonNull

--- a/app/src/main/java/com/wireguard/config/Peer.kt
+++ b/app/src/main/java/com/wireguard/config/Peer.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.config
 
 import com.wireguard.android.util.requireNonNull

--- a/app/src/main/java/com/wireguard/crypto/Curve25519.java
+++ b/app/src/main/java/com/wireguard/crypto/Curve25519.java
@@ -7,22 +7,20 @@
 package com.wireguard.crypto;
 
 import androidx.annotation.Nullable;
-
 import java.util.Arrays;
 
 /**
  * Implementation of the Curve25519 elliptic curve algorithm.
- * <p>
- * This implementation was imported to WireGuard from noise-java:
+ *
+ * <p>This implementation was imported to WireGuard from noise-java:
  * https://github.com/rweather/noise-java
- * <p>
- * This implementation is based on that from arduinolibs:
- * https://github.com/rweather/arduinolibs
- * <p>
- * Differences in this version are due to using 26-bit limbs for the
- * representation instead of the 8/16/32-bit limbs in the original.
- * <p>
- * References: http://cr.yp.to/ecdh.html, RFC 7748
+ *
+ * <p>This implementation is based on that from arduinolibs: https://github.com/rweather/arduinolibs
+ *
+ * <p>Differences in this version are due to using 26-bit limbs for the representation instead of
+ * the 8/16/32-bit limbs in the original.
+ *
+ * <p>References: http://cr.yp.to/ecdh.html, RFC 7748
  */
 @SuppressWarnings({"MagicNumber", "NonConstantFieldWithUpperCaseName", "SuspiciousNameCombination"})
 public final class Curve25519 {
@@ -47,9 +45,7 @@ public final class Curve25519 {
     private final int[] z_2;
     private final int[] z_3;
 
-    /**
-     * Constructs the temporary state holder for Curve25519 evaluation.
-     */
+    /** Constructs the temporary state holder for Curve25519 evaluation. */
     private Curve25519() {
         // Allocate memory for all of the temporary variables we will need.
         x_1 = new int[NUM_LIMBS_255BIT];
@@ -74,8 +70,8 @@ public final class Curve25519 {
      * Conditional swap of two values.
      *
      * @param select Set to 1 to swap, 0 to leave as-is.
-     * @param x      The first value.
-     * @param y      The second value.
+     * @param x The first value.
+     * @param y The second value.
      */
     private static void cswap(int select, final int[] x, final int[] y) {
         select = -select;
@@ -89,14 +85,17 @@ public final class Curve25519 {
     /**
      * Evaluates the Curve25519 curve.
      *
-     * @param result     Buffer to place the result of the evaluation into.
-     * @param offset     Offset into the result buffer.
+     * @param result Buffer to place the result of the evaluation into.
+     * @param offset Offset into the result buffer.
      * @param privateKey The private key to use in the evaluation.
-     * @param publicKey  The public key to use in the evaluation, or null
-     *                   if the base point of the curve should be used.
+     * @param publicKey The public key to use in the evaluation, or null if the base point of the
+     *     curve should be used.
      */
-    public static void eval(final byte[] result, final int offset,
-                            final byte[] privateKey, @Nullable final byte[] publicKey) {
+    public static void eval(
+            final byte[] result,
+            final int offset,
+            final byte[] privateKey,
+            @Nullable final byte[] publicKey) {
         final Curve25519 state = new Curve25519();
         try {
             // Unpack the public key value.  If null, use 9 as the base point.
@@ -126,11 +125,11 @@ public final class Curve25519 {
             }
 
             // Initialize the other temporary variables.
-            Arrays.fill(state.x_2, 0);            // x_2 = 1
+            Arrays.fill(state.x_2, 0); // x_2 = 1
             state.x_2[0] = 1;
-            Arrays.fill(state.z_2, 0);            // z_2 = 0
-            System.arraycopy(state.x_1, 0, state.x_3, 0, state.x_1.length);  // x_3 = x_1
-            Arrays.fill(state.z_3, 0);            // z_3 = 1
+            Arrays.fill(state.z_2, 0); // z_2 = 0
+            System.arraycopy(state.x_1, 0, state.x_3, 0, state.x_1.length); // x_3 = x_1
+            Arrays.fill(state.z_3, 0); // z_3 = 1
             state.z_3[0] = 1;
 
             // Evaluate the curve for every bit of the private key.
@@ -144,10 +143,10 @@ public final class Curve25519 {
             for (int index = 0; index < 32; ++index) {
                 final int bit = (index * 8) % 26;
                 final int word = (index * 8) / 26;
-                if (bit <= (26 - 8))
-                    result[offset + index] = (byte) (state.x_2[word] >> bit);
+                if (bit <= (26 - 8)) result[offset + index] = (byte) (state.x_2[word] >> bit);
                 else
-                    result[offset + index] = (byte) ((state.x_2[word] >> bit) | (state.x_2[word + 1] << (26 - bit)));
+                    result[offset + index] =
+                            (byte) ((state.x_2[word] >> bit) | (state.x_2[word + 1] << (26 - bit)));
             }
         } finally {
             // Clean up all temporary state before we exit.
@@ -159,8 +158,8 @@ public final class Curve25519 {
      * Subtracts two numbers modulo 2^255 - 19.
      *
      * @param result The result.
-     * @param x      The first number to subtract.
-     * @param y      The second number to subtract.
+     * @param x The first number to subtract.
+     * @param y The second number to subtract.
      */
     private static void sub(final int[] result, final int[] x, final int[] y) {
         int index;
@@ -191,8 +190,8 @@ public final class Curve25519 {
      * Adds two numbers modulo 2^255 - 19.
      *
      * @param result The result.
-     * @param x      The first number to add.
-     * @param y      The second number to add.
+     * @param x The first number to add.
+     * @param y The second number to add.
      */
     private void add(final int[] result, final int[] x, final int[] y) {
         int carry = x[0] + y[0];
@@ -204,9 +203,7 @@ public final class Curve25519 {
         reduceQuick(result);
     }
 
-    /**
-     * Destroy all sensitive data in this object.
-     */
+    /** Destroy all sensitive data in this object. */
     private void destroy() {
         // Destroy all temporary variables.
         Arrays.fill(x_1, 0);
@@ -250,22 +247,22 @@ public final class Curve25519 {
             swap = select;
 
             // Evaluate the curve.
-            add(A, x_2, z_2);               // A = x_2 + z_2
-            square(AA, A);                  // AA = A^2
-            sub(B, x_2, z_2);               // B = x_2 - z_2
-            square(BB, B);                  // BB = B^2
-            sub(E, AA, BB);                 // E = AA - BB
-            add(C, x_3, z_3);               // C = x_3 + z_3
-            sub(D, x_3, z_3);               // D = x_3 - z_3
-            mul(DA, D, A);                  // DA = D * A
-            mul(CB, C, B);                  // CB = C * B
-            add(x_3, DA, CB);               // x_3 = (DA + CB)^2
+            add(A, x_2, z_2); // A = x_2 + z_2
+            square(AA, A); // AA = A^2
+            sub(B, x_2, z_2); // B = x_2 - z_2
+            square(BB, B); // BB = B^2
+            sub(E, AA, BB); // E = AA - BB
+            add(C, x_3, z_3); // C = x_3 + z_3
+            sub(D, x_3, z_3); // D = x_3 - z_3
+            mul(DA, D, A); // DA = D * A
+            mul(CB, C, B); // CB = C * B
+            add(x_3, DA, CB); // x_3 = (DA + CB)^2
             square(x_3, x_3);
-            sub(z_3, DA, CB);               // z_3 = x_1 * (DA - CB)^2
+            sub(z_3, DA, CB); // z_3 = x_1 * (DA - CB)^2
             square(z_3, z_3);
             mul(z_3, z_3, x_1);
-            mul(x_2, AA, BB);               // x_2 = AA * BB
-            mulA24(z_2, E);                 // z_2 = E * (AA + a24 * E)
+            mul(x_2, AA, BB); // x_2 = AA * BB
+            mulA24(z_2, E); // z_2 = E * (AA + a24 * E)
             add(z_2, z_2, AA);
             mul(z_2, z_2, E);
 
@@ -294,8 +291,8 @@ public final class Curve25519 {
      * Multiplies two numbers modulo 2^255 - 19.
      *
      * @param result The result.
-     * @param x      The first number to multiply.
-     * @param y      The second number to multiply.
+     * @param x The first number to multiply.
+     * @param y The second number to multiply.
      */
     private void mul(final int[] result, final int[] x, final int[] y) {
         // Multiply the two numbers to create the intermediate result.
@@ -327,7 +324,7 @@ public final class Curve25519 {
      * Multiplies a number by the a24 constant, modulo 2^255 - 19.
      *
      * @param result The result.
-     * @param x      The number to multiply by a24.
+     * @param x The number to multiply by a24.
      */
     private void mulA24(final int[] result, final int[] x) {
         final long a24 = 121665;
@@ -344,8 +341,8 @@ public final class Curve25519 {
     /**
      * Raise x to the power of (2^250 - 1).
      *
-     * @param result The result.  Must not overlap with x.
-     * @param x      The argument.
+     * @param result The result. Must not overlap with x.
+     * @param x The argument.
      */
     private void pow250(final int[] result, final int[] x) {
         // The big-endian hexadecimal expansion of (2^250 - 1) is:
@@ -360,12 +357,10 @@ public final class Curve25519 {
 
         // Build a pattern of 250 bits in length of repeated copies of 0000000001.
         square(A, x);
-        for (int j = 0; j < 9; ++j)
-            square(A, A);
+        for (int j = 0; j < 9; ++j) square(A, A);
         mul(result, A, x);
         for (int i = 0; i < 23; ++i) {
-            for (int j = 0; j < 10; ++j)
-                square(A, A);
+            for (int j = 0; j < 10; ++j) square(A, A);
             mul(result, result, A);
         }
 
@@ -382,8 +377,8 @@ public final class Curve25519 {
     /**
      * Computes the reciprocal of a number modulo 2^255 - 19.
      *
-     * @param result The result.  Must not overlap with x.
-     * @param x      The argument.
+     * @param result The result. Must not overlap with x.
+     * @param x The argument.
      */
     private void recip(final int[] result, final int[] x) {
         // The reciprocal is the same as x ^ (p - 2) where p = 2^255 - 19.
@@ -407,9 +402,8 @@ public final class Curve25519 {
      * Reduce a number modulo 2^255 - 19.
      *
      * @param result The result.
-     * @param x      The value to be reduced.  This array will be
-     *               modified during the reduction.
-     * @param size   The number of limbs in the high order half of x.
+     * @param x The value to be reduced. This array will be modified during the reduction.
+     * @param size The number of limbs in the high order half of x.
      */
     private void reduce(final int[] result, final int[] x, final int size) {
         // Calculate (x mod 2^255) + ((x / 2^255) * 19) which will
@@ -457,8 +451,8 @@ public final class Curve25519 {
     }
 
     /**
-     * Reduces a number modulo 2^255 - 19 where it is known that the
-     * number can be reduced with only 1 trial subtraction.
+     * Reduces a number modulo 2^255 - 19 where it is known that the number can be reduced with only
+     * 1 trial subtraction.
      *
      * @param x The number to reduce, and the result.
      */
@@ -489,7 +483,7 @@ public final class Curve25519 {
      * Squares a number modulo 2^255 - 19.
      *
      * @param result The result.
-     * @param x      The number to square.
+     * @param x The number to square.
      */
     private void square(final int[] result, final int[] x) {
         mul(result, x, x);

--- a/app/src/main/java/com/wireguard/crypto/Key.java
+++ b/app/src/main/java/com/wireguard/crypto/Key.java
@@ -6,15 +6,14 @@
 package com.wireguard.crypto;
 
 import com.wireguard.crypto.KeyFormatException.Type;
-
 import java.security.SecureRandom;
 import java.util.Arrays;
 
 /**
  * Represents a WireGuard public or private key. This class uses specialized constant-time base64
  * and hexadecimal codec implementations that resist side-channel attacks.
- * <p>
- * Instances of this class are immutable.
+ *
+ * <p>Instances of this class are immutable.
  */
 @SuppressWarnings("MagicNumber")
 public final class Key {
@@ -24,7 +23,7 @@ public final class Key {
      * Constructs an object encapsulating the supplied key.
      *
      * @param key an array of bytes containing a binary key. Callers of this constructor are
-     *            responsible for ensuring that the array is of the correct length.
+     *     responsible for ensuring that the array is of the correct length.
      */
     private Key(final byte[] key) {
         // Defensively copy to ensure immutability.
@@ -34,22 +33,23 @@ public final class Key {
     /**
      * Decodes a single 4-character base64 chunk to an integer in constant time.
      *
-     * @param src       an array of at least 4 characters in base64 format
+     * @param src an array of at least 4 characters in base64 format
      * @param srcOffset the offset of the beginning of the chunk in {@code src}
      * @return the decoded 3-byte integer, or some arbitrary integer value if the input was not
-     * valid base64
+     *     valid base64
      */
     private static int decodeBase64(final char[] src, final int srcOffset) {
         int val = 0;
         for (int i = 0; i < 4; ++i) {
             final char c = src[i + srcOffset];
-            val |= (-1
-                    + ((((('A' - 1) - c) & (c - ('Z' + 1))) >>> 8) & (c - 64))
-                    + ((((('a' - 1) - c) & (c - ('z' + 1))) >>> 8) & (c - 70))
-                    + ((((('0' - 1) - c) & (c - ('9' + 1))) >>> 8) & (c + 5))
-                    + ((((('+' - 1) - c) & (c - ('+' + 1))) >>> 8) & 63)
-                    + ((((('/' - 1) - c) & (c - ('/' + 1))) >>> 8) & 64)
-            ) << (18 - 6 * i);
+            val |=
+                    (-1
+                                    + ((((('A' - 1) - c) & (c - ('Z' + 1))) >>> 8) & (c - 64))
+                                    + ((((('a' - 1) - c) & (c - ('z' + 1))) >>> 8) & (c - 70))
+                                    + ((((('0' - 1) - c) & (c - ('9' + 1))) >>> 8) & (c + 5))
+                                    + ((((('+' - 1) - c) & (c - ('+' + 1))) >>> 8) & 63)
+                                    + ((((('/' - 1) - c) & (c - ('/' + 1))) >>> 8) & 64))
+                            << (18 - 6 * i);
         }
         return val;
     }
@@ -57,25 +57,28 @@ public final class Key {
     /**
      * Encodes a single 4-character base64 chunk from 3 consecutive bytes in constant time.
      *
-     * @param src        an array of at least 3 bytes
-     * @param srcOffset  the offset of the beginning of the chunk in {@code src}
-     * @param dest       an array of at least 4 characters
+     * @param src an array of at least 3 bytes
+     * @param srcOffset the offset of the beginning of the chunk in {@code src}
+     * @param dest an array of at least 4 characters
      * @param destOffset the offset of the beginning of the chunk in {@code dest}
      */
-    private static void encodeBase64(final byte[] src, final int srcOffset,
-                                     final char[] dest, final int destOffset) {
+    private static void encodeBase64(
+            final byte[] src, final int srcOffset, final char[] dest, final int destOffset) {
         final byte[] input = {
-                (byte) ((src[srcOffset] >>> 2) & 63),
-                (byte) ((src[srcOffset] << 4 | ((src[1 + srcOffset] & 0xff) >>> 4)) & 63),
-                (byte) ((src[1 + srcOffset] << 2 | ((src[2 + srcOffset] & 0xff) >>> 6)) & 63),
-                (byte) ((src[2 + srcOffset]) & 63),
+            (byte) ((src[srcOffset] >>> 2) & 63),
+            (byte) ((src[srcOffset] << 4 | ((src[1 + srcOffset] & 0xff) >>> 4)) & 63),
+            (byte) ((src[1 + srcOffset] << 2 | ((src[2 + srcOffset] & 0xff) >>> 6)) & 63),
+            (byte) ((src[2 + srcOffset]) & 63),
         };
         for (int i = 0; i < 4; ++i) {
-            dest[i + destOffset] = (char) (input[i] + 'A'
-                    + (((25 - input[i]) >>> 8) & 6)
-                    - (((51 - input[i]) >>> 8) & 75)
-                    - (((61 - input[i]) >>> 8) & 15)
-                    + (((62 - input[i]) >>> 8) & 3));
+            dest[i + destOffset] =
+                    (char)
+                            (input[i]
+                                    + 'A'
+                                    + (((25 - input[i]) >>> 8) & 6)
+                                    - (((51 - input[i]) >>> 8) & 75)
+                                    - (((61 - input[i]) >>> 8) & 15)
+                                    + (((62 - input[i]) >>> 8) & 3));
         }
     }
 
@@ -101,18 +104,14 @@ public final class Key {
             key[i * 3 + 2] = (byte) (val & 0xff);
         }
         final char[] endSegment = {
-                input[i * 4],
-                input[i * 4 + 1],
-                input[i * 4 + 2],
-                'A',
+            input[i * 4], input[i * 4 + 1], input[i * 4 + 2], 'A',
         };
         final int val = decodeBase64(endSegment, 0);
         ret |= (val >>> 31) | (val & 0xff);
         key[i * 3] = (byte) ((val >>> 16) & 0xff);
         key[i * 3 + 1] = (byte) ((val >>> 8) & 0xff);
 
-        if (ret != 0)
-            throw new KeyFormatException(Format.BASE64, Type.CONTENTS);
+        if (ret != 0) throw new KeyFormatException(Format.BASE64, Type.CONTENTS);
         return new Key(key);
     }
 
@@ -169,8 +168,7 @@ public final class Key {
             cVal = (cNum0 & cNum) | (cAlpha0 & cAlpha);
             key[i] = (byte) (cAcc | cVal);
         }
-        if (ret != 0)
-            throw new KeyFormatException(Format.HEX, Type.CONTENTS);
+        if (ret != 0) throw new KeyFormatException(Format.HEX, Type.CONTENTS);
         return new Key(key);
     }
 
@@ -219,12 +217,9 @@ public final class Key {
     public String toBase64() {
         final char[] output = new char[Format.BASE64.length];
         int i;
-        for (i = 0; i < key.length / 3; ++i)
-            encodeBase64(key, i * 3, output, i * 4);
+        for (i = 0; i < key.length / 3; ++i) encodeBase64(key, i * 3, output, i * 4);
         final byte[] endSegment = {
-                key[i * 3],
-                key[i * 3 + 1],
-                0,
+            key[i * 3], key[i * 3 + 1], 0,
         };
         encodeBase64(endSegment, 0, output, i * 4);
         output[Format.BASE64.length - 1] = '=';
@@ -239,17 +234,14 @@ public final class Key {
     public String toHex() {
         final char[] output = new char[Format.HEX.length];
         for (int i = 0; i < key.length; ++i) {
-            output[i * 2] = (char) (87 + (key[i] >> 4 & 0xf)
-                    + ((((key[i] >> 4 & 0xf) - 10) >> 8) & ~38));
-            output[i * 2 + 1] = (char) (87 + (key[i] & 0xf)
-                    + ((((key[i] & 0xf) - 10) >> 8) & ~38));
+            output[i * 2] =
+                    (char) (87 + (key[i] >> 4 & 0xf) + ((((key[i] >> 4 & 0xf) - 10) >> 8) & ~38));
+            output[i * 2 + 1] = (char) (87 + (key[i] & 0xf) + ((((key[i] & 0xf) - 10) >> 8) & ~38));
         }
         return new String(output);
     }
 
-    /**
-     * The supported formats for encoding a WireGuard key.
-     */
+    /** The supported formats for encoding a WireGuard key. */
     public enum Format {
         BASE64(44),
         BINARY(32),
@@ -265,5 +257,4 @@ public final class Key {
             return length;
         }
     }
-
 }

--- a/app/src/main/java/com/wireguard/crypto/KeyFormatException.kt
+++ b/app/src/main/java/com/wireguard/crypto/KeyFormatException.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.crypto
 
 /**

--- a/app/src/main/java/com/wireguard/crypto/KeyFormatException.kt
+++ b/app/src/main/java/com/wireguard/crypto/KeyFormatException.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.crypto
 
 /**

--- a/app/src/main/java/com/wireguard/crypto/KeyPair.kt
+++ b/app/src/main/java/com/wireguard/crypto/KeyPair.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.crypto
 
 /**

--- a/app/src/main/java/com/wireguard/crypto/KeyPair.kt
+++ b/app/src/main/java/com/wireguard/crypto/KeyPair.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.crypto
 
 /**

--- a/app/src/main/java/com/wireguard/util/Keyed.kt
+++ b/app/src/main/java/com/wireguard/util/Keyed.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.util
 
 /**

--- a/app/src/main/java/com/wireguard/util/Keyed.kt
+++ b/app/src/main/java/com/wireguard/util/Keyed.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.util
 
 /**

--- a/app/src/main/java/com/wireguard/util/KeyedList.kt
+++ b/app/src/main/java/com/wireguard/util/KeyedList.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.util
 
 /**

--- a/app/src/main/java/com/wireguard/util/KeyedList.kt
+++ b/app/src/main/java/com/wireguard/util/KeyedList.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.util
 
 /**

--- a/app/src/main/java/com/wireguard/util/SortedKeyedList.kt
+++ b/app/src/main/java/com/wireguard/util/SortedKeyedList.kt
@@ -1,8 +1,7 @@
 /*
- * Copyright © 2017-2018 WireGuard LLC. All Rights Reserved.
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
- */
-
+*/
 package com.wireguard.util
 
 import java.util.Comparator

--- a/app/src/main/java/com/wireguard/util/SortedKeyedList.kt
+++ b/app/src/main/java/com/wireguard/util/SortedKeyedList.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 package com.wireguard.util
 
 import java.util.Comparator

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:3.3.0")
         classpath(kotlin("gradle-plugin", "1.3.20"))
+        classpath("com.diffplug.spotless:spotless-plugin-gradle:3.17.0")
     }
 }
 

--- a/ci/style-check.sh
+++ b/ci/style-check.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-wget https://github.com/shyiko/ktlint/releases/download/0.29.0/ktlint
-chmod +x ktlint
-./ktlint "${TRAVIS_BUILD_DIR}"/app/src/main/**/*.kt

--- a/spotless.gradle
+++ b/spotless.gradle
@@ -1,0 +1,21 @@
+apply plugin: "com.diffplug.gradle.spotless"
+spotless {
+  java {
+    target "**/*.java"
+    trimTrailingWhitespace()
+    removeUnusedImports()
+    googleJavaFormat().aosp()
+    endWithNewline()
+  }
+  kotlin {
+    target "**/*.kt"
+    ktlint("0.30.0").userData(['indent_size': '4', 'continuation_indent_size': '4'])
+    licenseHeaderFile '../spotless.license.kt'
+    trimTrailingWhitespace()
+    endWithNewline()
+  }
+  kotlinGradle {
+    target '*.gradle.kts', '**/build.gradle.kts'
+    ktlint().userData(['indent_size': '4', 'continuation_indent_size' : '4'])
+  }
+}

--- a/spotless.license.kt
+++ b/spotless.license.kt
@@ -1,4 +1,4 @@
 /*
  * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */

--- a/spotless.license.kt
+++ b/spotless.license.kt
@@ -1,0 +1,4 @@
+/*
+ * Copyright © 2019 Harsh Shandilya. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+*/


### PR DESCRIPTION
- Add the plugin with google's AOSP code format to retain 4-space indents and
force it to use ktlint 0.30.0 since whatever diffplug has shipped with spotless
is too old to correctly handle the Gradle Kotlin DSL stable release.
- Update CI to use spotlessCheck task rather than manually run ktlint.