### PR TITLE
Tasker support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,7 +101,7 @@ dependencies {
     implementation("androidx.databinding:databinding-adapters:3.3.1")
     implementation("androidx.databinding:databinding-runtime:3.3.1")
     implementation("androidx.fragment:fragment-ktx:1.0.0")
-    implementation("androidx.preference:preference:1.0.0")
+    implementation("androidx.preference:preference:1.1.0-alpha03")
     implementation("com.google.android.material:material:1.0.0")
     implementation("com.google.zxing:core:3.3.3")
     implementation("com.jakewharton.threetenabp:threetenabp:1.1.2")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,6 +62,8 @@
         <receiver android:name=".model.TunnelManager$IntentReceiver">
             <intent-filter>
                 <action android:name="com.wireguard.android.action.REFRESH_TUNNEL_STATES" />
+                <action android:name="${applicationId}.SET_TUNNEL_UP" />
+                <action android:name="${applicationId}.SET_TUNNEL_DOWN" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/com/wireguard/android/activity/BaseActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/BaseActivity.kt
@@ -50,9 +50,9 @@ abstract class BaseActivity : ThemeChangeAwareActivity() {
         super.onCreate(savedInstanceState)
     }
 
-    override fun onSaveInstanceState(outState: Bundle?) {
+    override fun onSaveInstanceState(outState: Bundle) {
         selectedTunnel?.let {
-            outState?.putString(KEY_SELECTED_TUNNEL, it.name)
+            outState.putString(KEY_SELECTED_TUNNEL, it.name)
         }
         super.onSaveInstanceState(outState)
     }

--- a/app/src/main/java/com/wireguard/android/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/SettingsActivity.kt
@@ -13,6 +13,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.transaction
 import androidx.preference.CheckBoxPreference
+import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
@@ -107,6 +108,7 @@ class SettingsActivity : ThemeChangeAwareActivity() {
             val exclusionsPref = preferenceManager.findPreference<Preference>(ApplicationPreferences.globalExclusionsKey)
             val whitelistAppsPref = preferenceManager.findPreference<CheckBoxPreference>(ApplicationPreferences.whitelistAppsKey)
             val forceUserspaceBackendPref = preferenceManager.findPreference<SwitchPreferenceCompat>(ApplicationPreferences.forceUserspaceBackendkey)
+            val integrationSecretPref = preferenceManager.findPreference<EditTextPreference>(ApplicationPreferences.taskerIntegrationSecretKey)
             for (pref in wgQuickOnlyPrefs + wgOnlyPrefs + debugOnlyPrefs)
                 pref.isVisible = false
 
@@ -141,6 +143,14 @@ class SettingsActivity : ThemeChangeAwareActivity() {
             forceUserspaceBackendPref?.setOnPreferenceClickListener {
                 context?.restartApplication()
                 true
+            }
+            integrationSecretPref.setSummaryProvider { preference ->
+                if (ApplicationPreferences.allowTaskerIntegration &&
+                    preference.isEnabled &&
+                    ApplicationPreferences.taskerIntegrationSecret.isEmpty())
+                    getString(R.string.tasker_integration_summary_empty_secret)
+                else
+                    getString(R.string.tasker_integration_secret_summary)
             }
         }
 

--- a/app/src/main/java/com/wireguard/android/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/SettingsActivity.kt
@@ -12,7 +12,10 @@ import android.view.MenuItem
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.transaction
+import androidx.preference.CheckBoxPreference
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreferenceCompat
 import com.wireguard.android.Application
 import com.wireguard.android.BuildConfig
 import com.wireguard.android.R
@@ -92,15 +95,18 @@ class SettingsActivity : ThemeChangeAwareActivity() {
             addPreferencesFromResource(R.xml.preferences)
             val screen = preferenceScreen
             val wgQuickOnlyPrefs = arrayOf(
-                preferenceScreen.findPreference("tools_installer"),
-                preferenceScreen.findPreference("restore_on_boot")
+                preferenceScreen.findPreference<Preference>("tools_installer"),
+                preferenceScreen.findPreference<CheckBoxPreference>("restore_on_boot")
             )
             val debugOnlyPrefs = arrayOf(
-                preferenceScreen.findPreference(ApplicationPreferences.forceUserspaceBackendkey)
+                preferenceScreen.findPreference<SwitchPreferenceCompat>(ApplicationPreferences.forceUserspaceBackendkey)
             )
             val wgOnlyPrefs = arrayOf(
-                preferenceScreen.findPreference(ApplicationPreferences.whitelistAppsKey)
+                preferenceScreen.findPreference<CheckBoxPreference>(ApplicationPreferences.whitelistAppsKey)
             )
+            val exclusionsPref = preferenceManager.findPreference<Preference>(ApplicationPreferences.globalExclusionsKey)
+            val whitelistAppsPref = preferenceManager.findPreference<CheckBoxPreference>(ApplicationPreferences.whitelistAppsKey)
+            val forceUserspaceBackendPref = preferenceManager.findPreference<SwitchPreferenceCompat>(ApplicationPreferences.forceUserspaceBackendkey)
             for (pref in wgQuickOnlyPrefs + wgOnlyPrefs + debugOnlyPrefs)
                 pref.isVisible = false
 
@@ -122,17 +128,17 @@ class SettingsActivity : ThemeChangeAwareActivity() {
                         screen.removePreference(pref)
                 }
             }
-            preferenceManager.findPreference(ApplicationPreferences.globalExclusionsKey).setOnPreferenceClickListener {
+            exclusionsPref.setOnPreferenceClickListener {
                 val excludedApps = ArrayList<String>(ApplicationPreferences.exclusionsArray)
                 val fragment = AppListDialogFragment.newInstance(excludedApps, true, this)
-                fragment.show(fragmentManager, null)
+                fragment.show(requireFragmentManager(), null)
                 true
             }
-            preferenceManager.findPreference(ApplicationPreferences.whitelistAppsKey)?.setOnPreferenceClickListener {
+            whitelistAppsPref?.setOnPreferenceClickListener {
                 Application.tunnelManager.restartActiveTunnels()
                 true
             }
-            preferenceManager.findPreference(ApplicationPreferences.forceUserspaceBackendkey)?.setOnPreferenceClickListener {
+            forceUserspaceBackendPref?.setOnPreferenceClickListener {
                 context?.restartApplication()
                 true
             }

--- a/app/src/main/java/com/wireguard/android/fragment/BaseFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/BaseFragment.kt
@@ -43,7 +43,7 @@ abstract class BaseFragment : Fragment(), OnSelectedTunnelChangedListener {
             activity?.selectedTunnel = tunnel
         }
 
-    override fun onAttach(context: Context?) {
+    override fun onAttach(context: Context) {
         super.onAttach(context)
         if (context is BaseActivity) {
             activity = context

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelDetailFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelDetailFragment.kt
@@ -30,8 +30,8 @@ class TunnelDetailFragment : BaseFragment() {
         setHasOptionsMenu(true)
     }
 
-    override fun onCreateOptionsMenu(menu: Menu?, inflater: MenuInflater?) {
-        inflater?.inflate(R.menu.tunnel_detail, menu)
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.tunnel_detail, menu)
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelEditorFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelEditorFragment.kt
@@ -75,7 +75,7 @@ class TunnelEditorFragment : BaseFragment(), AppExclusionListener {
         setHasOptionsMenu(true)
     }
 
-    override fun onCreateOptionsMenu(menu: Menu?, inflater: MenuInflater?) {
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater?.inflate(R.menu.config_editor, menu)
     }
 
@@ -138,8 +138,8 @@ class TunnelEditorFragment : BaseFragment(), AppExclusionListener {
             }
     }
 
-    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
-        when (item?.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
             R.id.menu_action_save -> {
                 val newConfig: Config?
                 try {

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
@@ -61,7 +61,7 @@ class TunnelListFragment : BaseFragment() {
 
             // Config text is valid, now create the tunnel…
             fragmentManager?.let {
-                ConfigNamingDialogFragment.newInstance(configText).show(fragmentManager, null)
+                ConfigNamingDialogFragment.newInstance(configText).show(it, null)
             }
         } catch (exception: Exception) {
             onTunnelImportFinished(emptyList(), listOf<Throwable>(exception))

--- a/app/src/main/java/com/wireguard/android/model/TunnelManager.kt
+++ b/app/src/main/java/com/wireguard/android/model/TunnelManager.kt
@@ -255,11 +255,11 @@ class TunnelManager(private var configStore: ConfigStore) : BaseObservable() {
                     return
                 }
                 "${BuildConfig.APPLICATION_ID}.SET_TUNNEL_UP" -> {
-                    tunnelName = intent.getStringExtra("tunnel_name")
+                    tunnelName = intent.getStringExtra(TUNNEL_NAME_INTENT_EXTRA)
                     state = Tunnel.State.UP
                 }
                 "${BuildConfig.APPLICATION_ID}.SET_TUNNEL_DOWN" -> {
-                    tunnelName = intent.getStringExtra("tunnel_name")
+                    tunnelName = intent.getStringExtra(TUNNEL_NAME_INTENT_EXTRA)
                     state = Tunnel.State.DOWN
                 }
                 else -> Timber.tag("IntentReceiver").d("Invalid intent action: ${intent.action}")
@@ -287,6 +287,7 @@ class TunnelManager(private var configStore: ConfigStore) : BaseObservable() {
         private const val KEY_LAST_USED_TUNNEL = "last_used_tunnel"
         private const val KEY_RESTORE_ON_BOOT = "restore_on_boot"
         private const val KEY_RUNNING_TUNNELS = "enabled_configs"
+        private const val TUNNEL_NAME_INTENT_EXTRA = "tunnel_name"
 
         internal fun getTunnelState(tunnel: Tunnel): CompletionStage<Tunnel.State> {
             return Application.asyncWorker.supplyAsync { Application.backend.getState(tunnel) }

--- a/app/src/main/java/com/wireguard/android/util/ApplicationPreferences.kt
+++ b/app/src/main/java/com/wireguard/android/util/ApplicationPreferences.kt
@@ -13,6 +13,9 @@ object ApplicationPreferences {
     const val globalExclusionsKey = "global_exclusions"
     const val forceUserspaceBackendkey = "force_userspace_backend"
     const val whitelistAppsKey = "whitelist_exclusions"
+    private const val allowTaskerIntegrationKey = "allow_tasker_integration"
+    private const val taskerIntegrationSecretKey = "intent_integration_secret"
+
     var exclusions: String
         get() = Application.sharedPreferences.getString(globalExclusionsKey, "") ?: ""
         set(value) {
@@ -32,4 +35,10 @@ object ApplicationPreferences {
 
     val whitelistApps: Boolean
         get() = Application.sharedPreferences.getBoolean(whitelistAppsKey, false)
+
+    val allowTaskerIntegration: Boolean
+        get() = Application.sharedPreferences.getBoolean(allowTaskerIntegrationKey, false)
+
+    val taskerIntegrationSecret: String
+        get() = Application.sharedPreferences.getString(taskerIntegrationSecretKey, "") ?: ""
 }

--- a/app/src/main/java/com/wireguard/android/util/ApplicationPreferences.kt
+++ b/app/src/main/java/com/wireguard/android/util/ApplicationPreferences.kt
@@ -13,8 +13,8 @@ object ApplicationPreferences {
     const val globalExclusionsKey = "global_exclusions"
     const val forceUserspaceBackendkey = "force_userspace_backend"
     const val whitelistAppsKey = "whitelist_exclusions"
+    const val taskerIntegrationSecretKey = "intent_integration_secret"
     private const val allowTaskerIntegrationKey = "allow_tasker_integration"
-    private const val taskerIntegrationSecretKey = "intent_integration_secret"
 
     var exclusions: String
         get() = Application.sharedPreferences.getString(globalExclusionsKey, "") ?: ""

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,4 +185,5 @@
     <string name="tasker_integration_summary">WARNING: This is a potential security risk! Avoid using this on rooted devices, malicious apps can very easily circumvent the protection put in place by Viscerion!</string>
     <string name="tasker_integration_secret_title">External intent secret</string>
     <string name="tasker_integration_secret_summary">Secured secret to ensure only trusted clients can control tunnels. This cannot be empty!</string>
+    <string name="tasker_integration_summary_empty_secret">Setting a secret here is mandatory!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,4 +181,8 @@
     <string name="preference_category_config">Tunnel configurations</string>
     <string name="preference_category_debugging">Debugging</string>
     <string name="preference_category_theme">Theming</string>
+    <string name="tasker_integration_title">Enable tasker integration</string>
+    <string name="tasker_integration_summary">WARNING: This is a potential security risk! Avoid using this on rooted devices, malicious apps can very easily circumvent the protection put in place by Viscerion!</string>
+    <string name="tasker_integration_secret_title">External intent secret</string>
+    <string name="tasker_integration_secret_summary">Secured secret to ensure only trusted clients can control tunnels. This cannot be empty!</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -25,6 +25,17 @@
             android:key="global_exclusions"
             android:title="@string/global_exclusions_title"
             android:summary="@string/global_exclusions_summary" />
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="allow_tasker_integration"
+            android:title="@string/tasker_integration_title"
+            android:summary="@string/tasker_integration_summary" />
+        <EditTextPreference
+            android:defaultValue=""
+            android:dependency="allow_tasker_integration"
+            android:key="intent_integration_secret"
+            android:title="@string/tasker_integration_secret_title"
+            android:summary="@string/tasker_integration_secret_summary" />
         <com.wireguard.android.preference.ToolsInstallerPreference android:key="tools_installer" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/preference_category_debugging">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -10,15 +10,6 @@
             android:title="@string/theme_title"
             android:summary="@string/theme_summary"/>
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/preference_category_debugging">
-        <com.wireguard.android.preference.ZipExporterPreference />
-        <com.wireguard.android.preference.LogExporterPreference />
-        <SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="force_userspace_backend"
-            android:title="@string/force_userspace_backend_title"
-            android:summary="@string/force_userspace_backend_summary" />
-    </PreferenceCategory>
     <PreferenceCategory android:title="@string/preference_category_config">
         <CheckBoxPreference
             android:defaultValue="false"
@@ -35,5 +26,14 @@
             android:title="@string/global_exclusions_title"
             android:summary="@string/global_exclusions_summary" />
         <com.wireguard.android.preference.ToolsInstallerPreference android:key="tools_installer" />
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/preference_category_debugging">
+        <com.wireguard.android.preference.ZipExporterPreference />
+        <com.wireguard.android.preference.LogExporterPreference />
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="force_userspace_backend"
+            android:title="@string/force_userspace_backend_title"
+            android:summary="@string/force_userspace_backend_summary" />
     </PreferenceCategory>
 </androidx.preference.PreferenceScreen>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
                 val rejected = listOf("alpha", "beta", "rc", "cr", "m", "preview")
                     .map { qualifier -> Regex("(?i).*[.-]$qualifier[.\\d-]*") }
                     .any { it.matches(candidate.version) }
-                if (rejected) {
+                if (rejected && !(candidate.group == "androidx.preference")) {
                     reject("Release candidate")
                 }
             }


### PR DESCRIPTION
Adds two new intent receivers to toggle tunnel state.

- `${PACKAGE_NAME}.SET_TUNNEL_UP` to start a tunnel
- `${PACKAGE_NAME}.SET_TUNNEL_DOWN` to tear it down.

Both receivers take a mandatory `tunnel_name` intent extra which is used by tunnel manager to find the tunnel to change state for as well as a `integration_secret` extra that has to be set in settings to be able to ensure only the right apps are allowed to toggle tunnel state. Empty integration secret is not permitted and the receiver will reject all incoming intents.

Fixes: #111