### PR TITLE
Task configuration improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,7 @@ branches:
     - master
 
 script:
-  - |
-      ./gradlew spotlessCheck && \
-      ./gradlew assemble$BUILD_TYPE check$BUILD_TYPE
+  - ./gradlew assemble$BUILD_TYPE check$BUILD_TYPE
 
 notifications:
   email: false

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -125,3 +125,11 @@ tasks.withType<KotlinCompile> {
 kapt {
     useBuildCache = true
 }
+
+afterEvaluate {
+    val assembleTask = tasks.findByName("assembleDebug") ?: tasks.findByName("assembleRelease")
+    val dependencies = mutableListOf()
+    dependencies += rootProject.tasks.getByName("spotlessCheck")
+    if (dependencies.isNotEmpty())
+        assembleTask?.setDependsOn(dependencies)
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,6 @@ plugins {
 // Create a variable called keystorePropertiesFile, and initialize it to your
 // keystore.properties file, in the rootProject folder.
 val keystorePropertiesFile = rootProject.file("keystore.properties")
-val buildTypeRelease = "release"
 
 fun gitHash(): String {
     return try {
@@ -50,7 +49,7 @@ android {
         keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 
         signingConfigs {
-            create(buildTypeRelease) {
+            create("release") {
                 keyAlias = keystoreProperties["keyAlias"].toString()
                 keyPassword = keystoreProperties["keyPassword"].toString()
                 storeFile = rootProject.file(keystoreProperties["storeFile"].toString())
@@ -59,7 +58,7 @@ android {
         }
     }
     buildTypes {
-        getByName(buildTypeRelease) {
+        getByName("release") {
             if (keystorePropertiesFile.exists()) signingConfig = signingConfigs.getByName("release")
             externalNativeBuild {
                 cmake {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -129,6 +129,8 @@ afterEvaluate {
     val assembleTask = tasks.findByName("assembleDebug") ?: tasks.findByName("assembleRelease")
     val dependencies = mutableListOf()
     dependencies += rootProject.tasks.getByName("spotlessCheck")
-    if (dependencies.isNotEmpty())
+    if (dependencies.isNotEmpty()) {
+        assembleTask?.dependsOn?.forEach { dependencies += it }
         assembleTask?.setDependsOn(dependencies)
+    }
 }

--- a/buildSrc/src/main/kotlin/me/msfjarvis/viscerion/build/SpotlessConfiguration.kt
+++ b/buildSrc/src/main/kotlin/me/msfjarvis/viscerion/build/SpotlessConfiguration.kt
@@ -28,7 +28,7 @@ fun Project.configureSpotless() {
                     mapOf(
                         "dir" to ".",
                         "include" to listOf("**/*.md", "**/.gitignore", "**/*.yaml", "**/*.yml"),
-                        "exclude" to listOf(".gradle/**", ".gradle-cache/**", "**/tools/**")
+                        "exclude" to listOf(".gradle/**", ".gradle-cache/**", "**/tools/**", "**/build/**")
                     )
                 )
             )


### PR DESCRIPTION
- Make assemble/assembleDebug/assembleRelease always run
  the spotlessCheck task. Catch style violations at build
  time to encourage clean code and save time rebasing
  style fixes when pushing.

- Ensure spotless misc format rule does not probe build directories